### PR TITLE
feat: added common package to parse Figma variables to Design Tokens (W3C) spec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,19 @@
         "import/no-unresolved": "off",
         "no-restricted-syntax": "off",
         "import/prefer-default-export": "off",
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+        "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+        "no-labels": "off",
+        "no-continue": "off",
+        "no-underscore-dangle": "off",
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "caughtErrorsIgnorePattern": "^_"
+          }
+        ]
+
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "@tfk-samf/design-system",
       "workspaces": [
         "packages/components",
-        "packages/tokens"
+        "packages/tokens",
+        "packages/figma-to-dtcg"
       ],
       "devDependencies": {
         "lerna": "^8.1.6"
@@ -645,6 +646,18 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@figma/plugin-typings": {
+      "version": "1.97.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.97.0.tgz",
+      "integrity": "sha512-AcmZey7TBbc43g2dO+9hjrcTbgb0UFY32do3to3rFU1OXb9hinsrmmbddyhD5105DHzRDac4oT7A5+VOow7p1Q==",
+      "dev": true
+    },
+    "node_modules/@figma/rest-api-spec": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@figma/rest-api-spec/-/rest-api-spec-0.16.0.tgz",
+      "integrity": "sha512-J/u7LIHGIKpm9jcJpoAcfUAEfgtuWTtNgIS94mhfdie3p1tgJSZxrJMQxg8u4V7T7SKMpjlqtMr1LwkWf1iC/A==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -2180,6 +2193,10 @@
     },
     "node_modules/@tfk-samf/components": {
       "resolved": "packages/components",
+      "link": true
+    },
+    "node_modules/@tfk-samf/figma-to-dtcg": {
+      "resolved": "packages/figma-to-dtcg",
       "link": true
     },
     "node_modules/@tfk-samf/tokens": {
@@ -11164,6 +11181,22 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "typescript": "^5.2.2",
         "vite": "^5.3.1"
+      }
+    },
+    "packages/figma-to-dtcg": {
+      "name": "@tfk-samf/figma-to-dtcg",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@figma/plugin-typings": "^1.97.0",
+        "@figma/rest-api-spec": "^0.16.0",
+        "@typescript-eslint/eslint-plugin": "^6.12.0",
+        "@typescript-eslint/parser": "^6.12.0",
+        "eslint": "^8.54.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-plugin-import": "^2.29.1",
+        "style-dictionary": "^4.0.0",
+        "tsx": "^4.15.2",
+        "typescript": "^5.3.2"
       }
     },
     "packages/tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11194,8 +11194,6 @@
         "eslint": "^8.54.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.1",
-        "style-dictionary": "^4.0.0",
-        "tsx": "^4.15.2",
         "typescript": "^5.3.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2207,6 +2207,10 @@
       "resolved": "packages/components",
       "link": true
     },
+    "node_modules/@tfk-samf/figma-dtcg-plugin": {
+      "resolved": "packages/figma-dtcg-plugin",
+      "link": true
+    },
     "node_modules/@tfk-samf/figma-to-dtcg": {
       "resolved": "packages/figma-to-dtcg",
       "link": true
@@ -3924,10 +3928,6 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
-    },
-    "node_modules/design-tokens-w3c-export": {
-      "resolved": "packages/figma-dtcg-plugin",
-      "link": true
     },
     "node_modules/detect-indent": {
       "version": "5.0.0",
@@ -11200,7 +11200,7 @@
       }
     },
     "packages/figma-dtcg-plugin": {
-      "name": "design-tokens-w3c-export",
+      "name": "@tfk-samf/figma-dtcg-plugin",
       "version": "0.1.1",
       "dependencies": {
         "@tfk-samf/figma-to-dtcg": "0.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "workspaces": [
         "packages/components",
         "packages/tokens",
-        "packages/figma-to-dtcg"
+        "packages/figma-to-dtcg",
+        "packages/figma-dtcg-plugin"
       ],
       "devDependencies": {
         "lerna": "^8.1.6"
@@ -645,6 +646,17 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@figma/eslint-plugin-figma-plugins": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@figma/eslint-plugin-figma-plugins/-/eslint-plugin-figma-plugins-0.15.0.tgz",
+      "integrity": "sha512-ol/v6qje8sxE2npvjCbOQUGlTx++RdYcq98jKaNokL/qN1IF7Y6Y7jgj2wiAYmT2V+aABvtX7MNtKKJ2fbcfWA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^6.13.2",
+        "@typescript-eslint/utils": "^6.12.0",
+        "typescript": "^5.3.2"
       }
     },
     "node_modules/@figma/plugin-typings": {
@@ -3912,6 +3924,10 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "node_modules/design-tokens-w3c-export": {
+      "resolved": "packages/figma-dtcg-plugin",
+      "link": true
     },
     "node_modules/detect-indent": {
       "version": "5.0.0",
@@ -11181,6 +11197,22 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "typescript": "^5.2.2",
         "vite": "^5.3.1"
+      }
+    },
+    "packages/figma-dtcg-plugin": {
+      "name": "design-tokens-w3c-export",
+      "version": "0.1.1",
+      "dependencies": {
+        "@tfk-samf/figma-to-dtcg": "0.0.1"
+      },
+      "devDependencies": {
+        "@figma/eslint-plugin-figma-plugins": "*",
+        "@figma/plugin-typings": "*",
+        "@typescript-eslint/eslint-plugin": "^6.12.0",
+        "@typescript-eslint/parser": "^6.12.0",
+        "eslint": "^8.54.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "typescript": "^5.3.2"
       }
     },
     "packages/figma-to-dtcg": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "workspaces": [
     "packages/components",
     "packages/tokens",
-    "packages/figma-to-dtcg"
+    "packages/figma-to-dtcg",
+    "packages/figma-dtcg-plugin"
   ],
   "scripts": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@tfk-samf/design-system",
   "workspaces": [
     "packages/components",
-    "packages/tokens"
+    "packages/tokens",
+    "packages/figma-to-dtcg"
   ],
   "scripts": {},
   "devDependencies": {

--- a/packages/figma-dtcg-plugin/README.md
+++ b/packages/figma-dtcg-plugin/README.md
@@ -1,0 +1,52 @@
+# Export Design Tokens (W3C) from Figma
+
+This plugin exports Figma variables into separate JSON files per collection and modes grouped in a .zip file for easy download. 
+
+## Background
+This plugin has been created for managing the design system of the public mobility collaboration (Offentlig Mobilitetssamarbeid [OMS]) in Norway. This project creates whitelabel software for the public transport sector, which can then be shared across the entire country. This means that multiple organisations are creating multiple themes using this design system. To manage the complexity, Figma variables are considered the source of truth for design decisions.
+
+## Flow
+The design system is structured in multiple layers.
+
+1. Base layer
+   
+  _The base layer defines color palettes and other scales that are not used directly, but define a coherent system of colors and values that will be used to define the rest of the design system._  
+  
+2. Semantic layer
+
+  _The sementic layer adds meaning to the variables from the `Base layer`. Semantic variables always reference to a variable in the base layer. Semantic variables are exported and will be used in implementations of products._
+  
+3. Implementation layer
+
+  _Using this plugin, variables are exported from Figma and imported into a Node project. [Amazon's Style Dictionary project](https://amzn.github.io/style-dictionary/) can parse these files and format them in any desired format, such as CSS Custom Properties of TypeScript variables. These variables can then be used directly in your web or native project._
+
+<img width="3184" alt="Flow of the design system, from color definition, definition of meaning for those colors and the use of those colors." src="https://github.com/TromsFylkestrafikk/figma-design-tokens/assets/162139399/bdd81e95-2704-4025-81db-7ab43872d94c">
+
+## Set-up variable collections
+Collections are a way to structure a group of variables in Figma. Each layer in this design system structure can contain multiple collections, which can be linked together.
+
+<img width="156" alt="Collections in Figma named base colors, colors, border, spacing and typography." src="https://github.com/TromsFylkestrafikk/figma-design-tokens/assets/162139399/69ec42b8-4a7a-4fce-babe-15ccbea52ed9">
+
+### Base colors
+This collection contains the color palette for each organization. It defines all shades of the colors in the palette, such as grey, orange, etcetera. 
+
+<img width="843" alt="Color collection in Figma defining HEX values for the used color palette." src="https://github.com/TromsFylkestrafikk/figma-design-tokens/assets/162139399/7cfd4b50-5dc1-4622-afd3-95d7ac5f039f">
+
+### Colors
+In this collection, meaning is defined to the base colors by referencing them and giving them a new name (an alias). This is where the dark and light themes per organization are built. 
+
+<img width="641" alt="Color collection in Figma with foreground, background, border, status and interaction colors." src="https://github.com/TromsFylkestrafikk/figma-design-tokens/assets/162139399/f9de1805-b7ff-469e-9104-e87d668128cf">
+
+### Border
+The border collection defines characteristics of the borders used throughout applications regardless of theme and organization. Note that border colors are defined in the `Colors` collection, since the colors are dependent on theme and organization.
+
+<img width="641" alt="Border collection in Figma with border radius and width values." src="https://github.com/TromsFylkestrafikk/figma-design-tokens/assets/162139399/13b027bf-dcbd-4b3b-8334-836451c7eab7">
+
+### Divide and conquer
+Collections are not limited to the ones described here. Any set of variables where a certain scale should be enforced is a candidate for the `Base layer`. Splitting the semantic layer up in ccollections can be particularly useful when we want to share variables across themes or organizations. They do not need to be redefined for each theme per organization, as per our `Border` collection.
+
+## Style Dictionary scripts
+_Coming soon..._
+
+## Usage with REST API
+_Coming soon..._

--- a/packages/figma-dtcg-plugin/index.ts
+++ b/packages/figma-dtcg-plugin/index.ts
@@ -54,5 +54,9 @@ function exportFiles(tokens: Tree) {
   });
 }
 
-const { tokens } = await useFigmaToDTCG();
+const { tokens } = await useFigmaToDTCG({
+  api: 'plugin',
+  client: figma,
+});
+
 exportFiles(tokens);

--- a/packages/figma-dtcg-plugin/index.ts
+++ b/packages/figma-dtcg-plugin/index.ts
@@ -1,0 +1,58 @@
+/**
+ *
+ * Main export code based on code by `jake-figma`
+ * https://github.com/jake-figma/figma-token-json
+ *
+ */
+import { useFigmaToDTCG } from '@tfk-samf/figma-to-dtcg';
+import type { Tree, Node } from '@tfk-samf/figma-to-dtcg';
+
+console.clear();
+console.log('------------------- Console cleared by Design Tokens (W3C) Export -------------------');
+
+figma.showUI(__html__);
+
+/**
+ * Exports generated files to .zip
+ *
+ * Takes a tree of design tokens, split is up by collection and mode
+ * and generates a file structure that is send to a .zip file.
+ *
+ * The generated structure is as follows, which is send to the front-end for download.
+ *
+ * ```
+ * {
+ *   [collection].[mode].json: json_content,
+ *   ...
+ * }
+ * ```
+ *
+ * @param tree A design token tree
+ */
+function exportFiles(tokens: Tree) {
+  const collections = Object.keys(tokens);
+
+  type FileName = string
+  const zipContent: Record<FileName, string> = {};
+
+  collections.forEach((collection) => {
+    const modes = Object.keys((tokens as Node)[collection]);
+
+    const isSingleMode = modes.length === 1;
+
+    modes.forEach((mode) => {
+      const fileName = `${collection}${isSingleMode ? '' : `.${mode}`}.json`;
+      const content = JSON.stringify(((tokens as Node)[collection] as Node)[mode], null, 2);
+      zipContent[fileName] = content;
+    });
+  });
+
+  figma.ui.postMessage({
+    type: 'download-zip',
+    contents: zipContent,
+    raw: JSON.stringify(tokens, null, 2),
+  });
+}
+
+const { tokens } = await useFigmaToDTCG();
+exportFiles(tokens);

--- a/packages/figma-dtcg-plugin/manifest.json
+++ b/packages/figma-dtcg-plugin/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Design Tokens (W3C) Export",
+  "id": "1377982390646186215",
+  "api": "1.0.0",
+  "main": "code.js",
+  "capabilities": [],
+  "enableProposedApi": false,
+  "documentAccess": "dynamic-page",
+  "editorType": [
+    "figma"
+  ],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/"
+    ]
+  },
+  "ui": "ui.html"
+}

--- a/packages/figma-dtcg-plugin/package.json
+++ b/packages/figma-dtcg-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "design-tokens-w3c-export",
+  "name": "@tfk-samf/figma-dtcg-plugin",
   "version": "0.1.1",
   "description": "Exports Figma variables into separate JSON files per collection and modes grouped in a .zip file for easy download.",
   "main": "dist/index.js",

--- a/packages/figma-dtcg-plugin/package.json
+++ b/packages/figma-dtcg-plugin/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "design-tokens-w3c-export",
+  "version": "0.1.1",
+  "description": "Exports Figma variables into separate JSON files per collection and modes grouped in a .zip file for easy download.",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint --ext .ts,.tsx --ignore-pattern node_modules .",
+    "lint:fix": "eslint --ext .ts,.tsx --ignore-pattern node_modules --fix .",
+    "watch": "npm run build -- --watch"
+  },
+  "author": "",
+  "license": "",
+  "dependencies": {
+    "@tfk-samf/figma-to-dtcg": "0.0.1"
+  },
+  "devDependencies": {
+    "@figma/eslint-plugin-figma-plugins": "*",
+    "@figma/plugin-typings": "*",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
+    "eslint": "^8.54.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "typescript": "^5.3.2"
+  },
+  "eslintConfig": {
+    "extends": [
+      "airbnb-base",
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@figma/figma-plugins/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "project": "./tsconfig.json"
+    },
+    "root": true,
+    "rules": {
+      "no-restricted-syntax": "off",
+      "no-await-in-loop": "off",
+      "no-labels": "off",
+      "no-continue": "off",
+      "no-console": "off",
+      "no-underscore-dangle": "off",
+      "no-use-before-define": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_"
+        }
+      ]
+    }
+  }
+}

--- a/packages/figma-dtcg-plugin/tsconfig.json
+++ b/packages/figma-dtcg-plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "files": ["./index.ts"],
+  "compilerOptions": {
+      "outDir": "dist",
+      "typeRoots": [
+          "../../node_modules/@figma"
+      ],
+      // Override default monorepo behaviour since we are not using Vite
+      "noEmit": false,
+      "allowImportingTsExtensions": false,
+  }
+}

--- a/packages/figma-dtcg-plugin/ui.html
+++ b/packages/figma-dtcg-plugin/ui.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
+    <script>
+        onmessage = (event) => {
+            const { type, contents, raw } = event.data.pluginMessage;
+            
+            if (type === 'download-zip') {
+                var zip = new JSZip();
+
+                Object.entries(contents).forEach(([ fname, content ]) => {
+                    zip.file(fname, content)
+                })
+
+                zip.generateAsync({ type: "blob" }).then((b) => {
+                    const url = URL.createObjectURL(b);
+        
+                    document.getElementById("raw").innerHTML = raw
+        
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `tokens.zip`;
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                })
+            }
+        };
+
+        parent.postMessage({ pluginMessage: { type: 'ready' } }, '*');
+    </script>
+</head>
+<body>
+    <pre>Exporting Figma variables...</pre>
+    <details>
+        <summary>
+            View raw
+        </summary>
+        <pre id="raw"></pre>
+    </details>
+</body>
+</html>
+

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -49,7 +49,7 @@ const response = await fetch("https://api.figma.com/v1/files/:file_key/variables
 })
 
 const { tokens } = await useFigmaToDTCG({
-    name: "rest",
+    api: "rest",
     response
 });
 ```

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -49,6 +49,3 @@ const { tokens } = await useFigmaToDTCG({
     response
 });
 ```
-
-
-

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -2,9 +2,7 @@
 
 This is a composable package that exports Figma variables in the Design Tokens (W3C) spec, regardless of Figma environment it is running in.  
 
-## Usage
-
-### Props
+## Props
 
 - `props`: `RestAPIProps` | `PluginAPIProps`
 
@@ -23,16 +21,18 @@ type RestAPIProps = {
 
 Import the package into your script and provide the necessary options.
 
-### Plugin
+## Usage
+
+### Inside a Figma Plugin
 
 ```ts
 import { useFigmaToDTCG } from '@tfk-samf/figma-to-dtcg';
 
-// Plugin API ios the default
+// Plugin API is the default
 const { tokens } = await useFigmaToDTCG();
 ```
 
-### Rest API
+### Using the Figma Variables Rest API
 
 ```ts
 import { useFigmaToDTCG } from "@tfk-samf/figma-to-dtcg"
@@ -45,7 +45,7 @@ const response = await fetch("https://api.figma.com/v1/files/:file_key/variables
 })
 
 const { tokens } = await useFigmaToDTCG({
-    // composable understands that we are using the RestAPI when we provide a response
+    // Understands that we are using the RestAPI when we provide a response
     response
 });
 ```

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -1,1 +1,54 @@
-# Figma to Design Tokens W3C spec
+# Figma to Design Tokens W3C Spec
+
+This is a composable package that exports Figma variables in the Design Tokens (W3C) spec, regardless of Figma environment it is running in.  
+
+## Usage
+
+### Props
+
+- `props`: `RestAPIProps` | `PluginAPIProps`
+
+`default`: `{ api: "plugin" }`
+
+```ts
+type PluginAPIProps = {
+    api?: 'plugin'
+}
+
+type RestAPIProps = {
+    api?: 'rest',
+    response: GetLocalVariablesResponse     // Response from Figma Rest API
+}
+```
+
+Import the package into your script and provide the necessary options.
+
+### Plugin
+
+```ts
+import { useFigmaToDTCG } from '@tfk-samf/figma-to-dtcg';
+
+// Plugin API ios the default
+const { tokens } = await useFigmaToDTCG();
+```
+
+### Rest API
+
+```ts
+import { useFigmaToDTCG } from "@tfk-samf/figma-to-dtcg"
+import { GetLocalVariablesResponse } from "@figma/rest-api-spec"
+
+const response = await fetch("https://api.figma.com/v1/files/:file_key/variables/local", {
+    headers: {
+        "X-FIGMA-TOKEN": ":figma_token",
+    }
+})
+
+const { tokens } = await useFigmaToDTCG({
+    // composable understands that we are using the RestAPI when we provide a response
+    response
+});
+```
+
+
+

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -25,11 +25,15 @@ Import the package into your script and provide the necessary options.
 
 ### Inside a Figma Plugin
 
+Configure your [Figma plugin with typings](https://www.figma.com/plugin-docs/api/typings/) and pass the Figma client to the composable.
+
 ```ts
 import { useFigmaToDTCG } from '@tfk-samf/figma-to-dtcg';
 
-// Plugin API is the default
-const { tokens } = await useFigmaToDTCG();
+const { tokens } = await useFigmaToDTCG({
+    api: "plugin",
+    client: figma
+});
 ```
 
 ### Using the Figma Variables Rest API
@@ -45,7 +49,7 @@ const response = await fetch("https://api.figma.com/v1/files/:file_key/variables
 })
 
 const { tokens } = await useFigmaToDTCG({
-    // Understands that we are using the RestAPI when we provide a response
+    name: "rest",
     response
 });
 ```

--- a/packages/figma-to-dtcg/README.md
+++ b/packages/figma-to-dtcg/README.md
@@ -1,0 +1,1 @@
+# Figma to Design Tokens W3C spec

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -3,7 +3,6 @@ import {
   LocalVariableCollection, VariableValue, LocalVariable, VariableAlias, GetLocalVariablesResponse,
 } from '@figma/rest-api-spec';
 
-const _figma = figma || undefined;
 
 let getVariableById: (id: string) => Promise<LocalVariable>;
 
@@ -213,10 +212,10 @@ async function useFigmaToDTCG(props: RestAPIProps | PluginAPIProps) {
 
   getVariableById = isRestApiEnv(props)
     ? (id: string) => Promise.resolve(props.response.meta.variables[id])
-    : (id: string) => _figma.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
+    : (id: string) => props.client.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
   const collections = isRestApiEnv(props)
     ? Object.values(props.response.meta.variableCollections)
-    : await _figma.variables.getLocalVariableCollectionsAsync();
+    : await props.client.variables.getLocalVariableCollectionsAsync();
 
   const tree: Tree = {};
   const { idToKey } = uniqueKeyIdMaps(collections, 'id', KEY_PREFIX_COLLECTION);

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -1,0 +1,243 @@
+/**
+ *
+ * Main export code based on code by `jake-figma`
+ * https://github.com/jake-figma/figma-token-json
+ *
+ */
+import {
+  RGB, RGBA,
+  LocalVariableCollection, VariableValue, LocalVariable, VariableAlias, GetLocalVariablesResponse,
+} from '@figma/rest-api-spec';
+
+let getVariableById: (id: string) => Promise<LocalVariable>;
+
+const KEY_PREFIX_COLLECTION = '';
+
+type OptionalExcept<T, K extends keyof T> = Pick<T, K> & Partial<T>
+type DesignTokenType = 'color' | 'number'
+type DesignToken = {
+  type: DesignTokenType
+  value: string | number | boolean | RGB | CompositeToken
+  }
+interface CompositeToken { [key: string]: DesignToken['value'] }
+type Token = DesignToken | CompositeToken
+
+type Tree = Token | { [key: string]: Tree };
+type Node = Exclude<Tree, Token>
+
+/**
+ * Converts an RGB(a) value to HEX
+ *
+ * @param color Color in RGB(a) format
+ * @returns Color in HEX format
+ */
+function rgbToHex({
+  r, g, b, a,
+}: RGBA) {
+  const toHex = (value: number) => {
+    const hex = Math.round(value * 255).toString(16);
+    return hex.length === 1 ? `0${hex}` : hex;
+  };
+
+  const hex = [toHex(r), toHex(g), toHex(b)];
+  if (a !== 1) {
+    hex.push(toHex(a));
+  }
+  return `#${hex.join('')}`;
+}
+
+/**
+ * Cleans the name of a variable according to Design Token (W3C) standard
+ *
+ * @param name Name of a variable
+ * @returns Name trimmed and snake_case
+ */
+function sanitizeName(name: string) {
+  return name
+    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .replace(/^ +/, '')
+    .replace(/ +$/, '')
+    .replace(/ +/g, '_')
+    .toLowerCase();
+}
+
+/**
+ * Checks if the name of a collection, group or variable is private.
+ *
+ * @param collection Name of the collection
+ * @returns True if private
+ */
+function isPrivate(collection: string) {
+  return collection.startsWith('_');
+}
+
+/**
+ * Map Figma ids to names of variables and collections
+ *
+ * @param nodesWithNames Collection of variables
+ * @param idKey The key of the id in the `nodesWithNames` parameter
+ * @param prefix If names should be prefixed
+ * @returns Functions that map from id to name and back
+ */
+function uniqueKeyIdMaps<T extends OptionalExcept<LocalVariableCollection, 'name'>, K extends keyof T, F extends T[K] &(string | number | symbol)>(nodesWithNames: T[], idKey: K, prefix = '') {
+  const idToKey: Record<F, string> = {} as Record<F, string>;
+  const keyToId: Record<string, T[K]> = {};
+  nodesWithNames.forEach((node) => {
+    const key = sanitizeName(node.name);
+    let int = 2;
+    let uniqueKey = `${prefix}${key}`;
+    while (keyToId[uniqueKey]) {
+      uniqueKey = `${prefix}${key}_${int}`;
+      int += 1;
+    }
+    keyToId[uniqueKey] = node[idKey];
+    idToKey[node[idKey] as F] = uniqueKey;
+  });
+  return { idToKey, keyToId };
+}
+
+/**
+ * Convert single variable to Design Token (W3C) standard
+ *
+ * @param name Name of the current variable
+ * @param value Value of the current variable
+ * @param type Type of current variable
+ * @returns Value of the variable in Design Token (W3C) standard
+ */
+async function valueToJSON(
+  name: string,
+  value: VariableValue,
+  type: LocalVariable['resolvedType'],
+): Promise<DesignToken['value']> {
+  const isAlias = (
+    v: VariableValue,
+  ): v is VariableAlias => !!(v as VariableAlias).type && !!(v as VariableAlias).id;
+
+  const isForeground = (
+    { name: _name }: LocalVariable,
+  ): boolean => !!_name.match(/^Foreground\/(Dark|Light)\/(Primary|Secondary|Disabled)$/);
+
+  const isColorPalette = (
+    { name: _name }: LocalVariable,
+  ): boolean => !!_name.match(/^[A-Za-z]+\/\d+\/Background$/);
+
+  let _value: DesignToken['value'];
+
+  // If the variable is a reference to another variable
+  if (isAlias(value)) {
+    // Get the referenced variable
+    const variable = (await getVariableById(value.id))!;
+    const alias = `{${variable.name.replace(/\//g, '.')}}`;
+
+    _value = alias;
+
+    // Expand the referenced variable if it is a foreground variable
+    if (isForeground(variable)) {
+      _value = {
+        Primary: alias,
+        Secondary: alias.replace('Primary', 'Secondary'),
+        Disabled: alias.replace('Primary', 'Disabled'),
+      };
+    }
+
+    // Expand the referenced variable if it is a reference to the color palette
+    // If the current variable is a foreground color, do not expand it to avoid circular references
+    if (isColorPalette(variable) && !isForeground({ name } as LocalVariable)) {
+      _value = {
+        Background: alias,
+        Foreground: alias.replace('Background', 'Foreground'),
+      };
+    }
+  } else {
+    // Return an actual value if the variable is not a reference
+    _value = type === 'COLOR' ? rgbToHex(value as RGBA) : value as string;
+  }
+
+  return _value;
+}
+
+/**
+ * Converts collection to Design Token (W3C) standard
+ *
+ * @param collection The variable collection to export
+ * @returns The collection in the Design Token (W3C) format
+ */
+async function collectionAsJSON(
+  { modes, variableIds }: LocalVariableCollection,
+) {
+  const collection: Record<string, Tree> = {};
+  const { idToKey, keyToId } = uniqueKeyIdMaps(modes, 'modeId');
+  const modeKeys = Object.values(idToKey);
+
+  modeKeys.forEach((mode: string) => {
+    collection[mode] = collection[mode] || {};
+  });
+
+  variables: for (const variableId of variableIds) {
+    const {
+      name,
+      resolvedType,
+      valuesByMode,
+    } = (await getVariableById(variableId))!;
+
+    for (const mode of modeKeys) {
+      let obj = collection[mode];
+      const value = valuesByMode[keyToId[mode]];
+
+      if (value !== undefined && ['COLOR', 'FLOAT'].includes(resolvedType)) {
+        const groups = name.split('/');
+        if (groups.some((group) => isPrivate(group))) continue variables;
+
+        groups.forEach((groupName) => {
+          obj = obj as Node;
+          obj[groupName] = obj[groupName] || {};
+          obj = obj[groupName];
+        });
+
+        obj.value = await valueToJSON(name, value, resolvedType);
+        obj.type = (resolvedType === 'COLOR' ? 'color' : 'number') as DesignTokenType;
+      }
+    }
+  }
+  return collection;
+}
+
+type RestAPIProps = {
+    response: GetLocalVariablesResponse
+}
+
+// This is a placeholder type
+type PluginAPIProps = {
+  name: string
+}
+
+async function useFigmaToDTCG(props?: RestAPIProps | PluginAPIProps) {
+  const isRestApiEnv = (p: typeof props): p is RestAPIProps => !!p && 'response' in p;
+
+  getVariableById = isRestApiEnv(props)
+    ? (id: string) => Promise.resolve(props.response.meta.variables[id])
+  // @ts-expect-error Figma types are globally imported and not recognized when bundling
+    : (id: string) => figma.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
+  const collections = isRestApiEnv(props)
+    ? Object.values(props.response.meta.variableCollections)
+  // @ts-expect-error Figma types are globally imported and not recognized when bundling
+    : await figma.variables.getLocalVariableCollectionsAsync();
+
+  const tree: Tree = {};
+  const { idToKey } = uniqueKeyIdMaps(collections, 'id', KEY_PREFIX_COLLECTION);
+
+  for (const collection of collections) {
+    const name = idToKey[collection.id];
+
+    // Skip this collection if private
+    if (isPrivate(name)) continue;
+
+    tree[name] = await collectionAsJSON(collection);
+  }
+
+  return {
+    tokens: tree,
+  };
+}
+
+export { useFigmaToDTCG };

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -203,24 +203,23 @@ async function collectionAsJSON(
 }
 
 type RestAPIProps = {
+    api?: 'rest'
     response: GetLocalVariablesResponse
 }
 
 // This is a placeholder type
 type PluginAPIProps = {
-  name: string
+  api?: 'plugin'
 }
 
-async function useFigmaToDTCG(props?: RestAPIProps | PluginAPIProps) {
-  const isRestApiEnv = (p: typeof props): p is RestAPIProps => !!p && 'response' in p;
+async function useFigmaToDTCG(props: RestAPIProps | PluginAPIProps = { api: 'plugin' }) {
+  const isRestApiEnv = (p: typeof props): p is RestAPIProps => p.api === 'rest';
 
   getVariableById = isRestApiEnv(props)
     ? (id: string) => Promise.resolve(props.response.meta.variables[id])
-  // @ts-expect-error Figma types are globally imported and not recognized when bundling
     : (id: string) => figma.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
   const collections = isRestApiEnv(props)
     ? Object.values(props.response.meta.variableCollections)
-  // @ts-expect-error Figma types are globally imported and not recognized when bundling
     : await figma.variables.getLocalVariableCollectionsAsync();
 
   const tree: Tree = {};

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -3,6 +3,8 @@ import {
   LocalVariableCollection, VariableValue, LocalVariable, VariableAlias, GetLocalVariablesResponse,
 } from '@figma/rest-api-spec';
 
+const _figma = figma || undefined;
+
 let getVariableById: (id: string) => Promise<LocalVariable>;
 
 const KEY_PREFIX_COLLECTION = '';
@@ -13,7 +15,8 @@ export type RestAPIProps = {
 }
 
 export type PluginAPIProps = {
-api?: 'plugin'
+  api?: 'plugin',
+  client: PluginAPI
 }
 
 type OptionalExcept<T, K extends keyof T> = Pick<T, K> & Partial<T>
@@ -205,15 +208,15 @@ async function collectionAsJSON(
   return collection;
 }
 
-async function useFigmaToDTCG(props: RestAPIProps | PluginAPIProps = { api: 'plugin' }) {
+async function useFigmaToDTCG(props: RestAPIProps | PluginAPIProps) {
   const isRestApiEnv = (p: typeof props): p is RestAPIProps => p.api === 'rest';
 
   getVariableById = isRestApiEnv(props)
     ? (id: string) => Promise.resolve(props.response.meta.variables[id])
-    : (id: string) => figma.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
+    : (id: string) => _figma.variables.getVariableByIdAsync(id) as Promise<LocalVariable>;
   const collections = isRestApiEnv(props)
     ? Object.values(props.response.meta.variableCollections)
-    : await figma.variables.getLocalVariableCollectionsAsync();
+    : await _figma.variables.getLocalVariableCollectionsAsync();
 
   const tree: Tree = {};
   const { idToKey } = uniqueKeyIdMaps(collections, 'id', KEY_PREFIX_COLLECTION);

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -1,9 +1,3 @@
-/**
- *
- * Main export code based on code by `jake-figma`
- * https://github.com/jake-figma/figma-token-json
- *
- */
 import {
   RGB, RGBA,
   LocalVariableCollection, VariableValue, LocalVariable, VariableAlias, GetLocalVariablesResponse,

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -13,17 +13,26 @@ let getVariableById: (id: string) => Promise<LocalVariable>;
 
 const KEY_PREFIX_COLLECTION = '';
 
+export type RestAPIProps = {
+  api?: 'rest'
+  response: GetLocalVariablesResponse
+}
+
+export type PluginAPIProps = {
+api?: 'plugin'
+}
+
 type OptionalExcept<T, K extends keyof T> = Pick<T, K> & Partial<T>
-type DesignTokenType = 'color' | 'number'
-type DesignToken = {
+export type DesignTokenType = 'color' | 'number'
+export type DesignToken = {
   type: DesignTokenType
   value: string | number | boolean | RGB | CompositeToken
   }
-interface CompositeToken { [key: string]: DesignToken['value'] }
-type Token = DesignToken | CompositeToken
+export interface CompositeToken { [key: string]: DesignToken['value'] }
+export type Token = DesignToken | CompositeToken
 
-type Tree = Token | { [key: string]: Tree };
-type Node = Exclude<Tree, Token>
+export type Tree = Token | { [key: string]: Tree };
+export type Node = Exclude<Tree, Token>
 
 /**
  * Converts an RGB(a) value to HEX
@@ -200,16 +209,6 @@ async function collectionAsJSON(
     }
   }
   return collection;
-}
-
-type RestAPIProps = {
-    api?: 'rest'
-    response: GetLocalVariablesResponse
-}
-
-// This is a placeholder type
-type PluginAPIProps = {
-  api?: 'plugin'
 }
 
 async function useFigmaToDTCG(props: RestAPIProps | PluginAPIProps = { api: 'plugin' }) {

--- a/packages/figma-to-dtcg/package.json
+++ b/packages/figma-to-dtcg/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "build": "tsc ./index.ts --declaration --outDir dist",
+    "build": "tsc",
     "lint": "eslint --ext .ts,.tsx .",
     "lint:fix": "eslint --ext .ts,.tsx --fix ."
   },
@@ -30,8 +30,6 @@
     "eslint": "^8.54.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "style-dictionary": "^4.0.0",
-    "tsx": "^4.15.2",
     "typescript": "^5.3.2"
   }
 }

--- a/packages/figma-to-dtcg/package.json
+++ b/packages/figma-to-dtcg/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@tfk-samf/figma-to-dtcg",
+  "version": "0.0.1",
+  "description": "The basis of the design system for the mobility department of Troms country.",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc ./index.ts --declaration --outDir dist",
+    "lint": "eslint --ext .ts,.tsx .",
+    "lint:fix": "eslint --ext .ts,.tsx --fix ."
+  },
+  "eslintConfig": {
+    "extends": "../../.eslintrc"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.97.0",
+    "@figma/rest-api-spec": "^0.16.0",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
+    "eslint": "^8.54.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "style-dictionary": "^4.0.0",
+    "tsx": "^4.15.2",
+    "typescript": "^5.3.2"
+  }
+}

--- a/packages/figma-to-dtcg/tsconfig.json
+++ b/packages/figma-to-dtcg/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "typeRoots": [
+            "../../node_modules/@figma"
+        ]
+    }
+}

--- a/packages/figma-to-dtcg/tsconfig.json
+++ b/packages/figma-to-dtcg/tsconfig.json
@@ -1,9 +1,14 @@
 {
     "extends": "../../tsconfig.json",
+    "files": ["./index.ts"],
     "compilerOptions": {
+        "declaration": true,
         "outDir": "dist",
         "typeRoots": [
             "../../node_modules/@figma"
-        ]
+        ],
+        // Override default monorepo behaviour since we are not using Vite
+        "noEmit": false,
+        "allowImportingTsExtensions": false,
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
Extracted Figma variable parsing logic into its own package `@tfk-samf/figma-to-dtcg`, which is now used in the Figma plugin (now moved into this monorepo for easier local dependency management). The same package can now also be used in AtB's design system repo to parse design tokens.