### PR TITLE
fix: Aligned region/transport colors with app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11624,7 +11624,7 @@
         "vite-plugin-dts": "^4.0.0-beta.0"
       },
       "peerDependencies": {
-        "@tfk-samf/tokens": "^0.3.1",
+        "@tfk-samf/tokens": "^0.3.2",
         "vue": "^3.4.34",
         "vuetify": "^3.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12069,7 +12069,7 @@
     },
     "packages/tokens": {
       "name": "@tfk-samf/tokens",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "@tfk-samf/figma-to-dtcg": "^0.3.0",
         "@typescript-eslint/eslint-plugin": "^6.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11609,7 +11609,7 @@
     },
     "packages/components": {
       "name": "@tfk-samf/components",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "deepmerge": "^4.3.1"
       },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
     "vite-plugin-dts": "^4.0.0-beta.0"
   },
   "peerDependencies": {
-    "@tfk-samf/tokens": "^0.3.1",
+    "@tfk-samf/tokens": "^0.3.2",
     "vue": "^3.4.34",
     "vuetify": "^3.3.0"
   },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tfk-samf/components",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Vue components used for applications in Troms County.",
   "type": "module",
   "files": [

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tfk-samf/tokens",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Design tokens are the source of truth for design decisions in Troms county.",
   "type": "module",
   "files": [

--- a/packages/tokens/raw/theme.json
+++ b/packages/tokens/raw/theme.json
@@ -449,7 +449,7 @@
       }
     },
     "Transport": {
-      "Region": {
+      "City": {
         "Primary": {
           "value": {
             "Background": "{Blue.400.Background}",
@@ -467,7 +467,7 @@
           "prefix": "color"
         }
       },
-      "City": {
+      "Region": {
         "Primary": {
           "value": {
             "Background": "{Green.700.Background}",
@@ -628,6 +628,18 @@
           "type": "color",
           "prefix": "color"
         }
+      }
+    },
+    "Zone": {
+      "From": {
+        "value": "#ffffff",
+        "type": "color",
+        "prefix": "color"
+      },
+      "To": {
+        "value": "#ffffff",
+        "type": "color",
+        "prefix": "color"
       }
     }
   },
@@ -1081,7 +1093,7 @@
       }
     },
     "Transport": {
-      "Region": {
+      "City": {
         "Primary": {
           "value": {
             "Background": "{Blue.400.Background}",
@@ -1099,7 +1111,7 @@
           "prefix": "color"
         }
       },
-      "City": {
+      "Region": {
         "Primary": {
           "value": {
             "Background": "{Green.700.Background}",
@@ -1260,6 +1272,18 @@
           "type": "color",
           "prefix": "color"
         }
+      }
+    },
+    "Zone": {
+      "From": {
+        "value": "#ffffff",
+        "type": "color",
+        "prefix": "color"
+      },
+      "To": {
+        "value": "#ffffff",
+        "type": "color",
+        "prefix": "color"
       }
     }
   }


### PR DESCRIPTION
Mixed up the `region` and `city` colors. `City` is supposed to be blue, in accordance with the Svipper app:

![image](https://github.com/user-attachments/assets/d3ca26ee-a5ac-48aa-a366-90099e57a83c)
