### PR TITLE
feat: Extended the definition of foreground

### DIFF
--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -177,7 +177,7 @@ async function valueToJSON(
 
   const isForeground = (
     { name: _name }: LocalVariable,
-  ): boolean => !!_name.match(/^Foreground\/([\w\s]+)\/(Primary|Secondary|Disabled)$/);
+  ): boolean => !!_name.match(/^Foreground\/([\w\s]+(?:\/[\w\s]+)?)\/(Primary|Secondary|Disabled|Info|Error|Interactive)$/);
 
   const isColorPalette = (
     { name: _name }: LocalVariable,

--- a/packages/figma-to-dtcg/index.ts
+++ b/packages/figma-to-dtcg/index.ts
@@ -177,7 +177,7 @@ async function valueToJSON(
 
   const isForeground = (
     { name: _name }: LocalVariable,
-  ): boolean => !!_name.match(/^Foreground\/([\w\s]+(?:\/[\w\s]+)?)\/(Primary|Secondary|Disabled|Info|Error|Interactive)$/);
+  ): boolean => !!_name.match(/^Foreground\/([\w\s]+)\/(Primary|Secondary|Disabled|Info|Error|Interactive|Success)$/);
 
   const isColorPalette = (
     { name: _name }: LocalVariable,


### PR DESCRIPTION
## Summary

- Extend the `isForeground` regex in `valueToJSON` to also match emphasis color variants (`Info`, `Error`, `Interactive`)

## Background

The `isForeground` check serves two purposes in `valueToJSON`:

1. Expanding foreground alias references into `{ Primary, Secondary, Disabled }` objects
2. **Preventing color palette expansion** — when a variable's name matches `isForeground`, the `isColorPalette` expansion into `{ Background, Foreground }` is suppressed

Emphasis variables like `Foreground/Emphasis/Info` alias to color palette entries (e.g. `Blue/500/Background`), but should resolve to flat hex values, not expanded `{ Background, Foreground }` objects. Without matching `isForeground`, they fall through to the `isColorPalette` expansion, changing their output shape and breaking consumers expecting a simple color string like `"#0959aa"`.

## Changes

Updated the regex from:
```
/^Foreground\/([\w\s]+)\/(Primary|Secondary|Disabled)$/
```
to:
```
/^Foreground\/([\w\s]+)\/(Primary|Secondary|Disabled|Info|Error|Interactive)$/
```

This keeps the strict, explicit matching pattern while ensuring emphasis colors are recognized as foreground variables and excluded from color palette expansion.
